### PR TITLE
Add the missing namespace in UserStore.cs

### DIFF
--- a/Storage/UserStore.cs
+++ b/Storage/UserStore.cs
@@ -1,6 +1,7 @@
 using BrickBreaker.Models;
-
 using System.Text.Json;
+
+namespace BrickBreaker.Storage;
 
 public sealed class UserStore
 {


### PR DESCRIPTION
Just quickly adding the missing `namespace BrickBreaker.Storage;` at the top of UserStore.cs, so other files can reference the class.