### PR TITLE
Ensured the program validates the username early and does not ask for…

### DIFF
--- a/BrickBreaker.Core/Logic/Auth.cs
+++ b/BrickBreaker.Core/Logic/Auth.cs
@@ -8,12 +8,21 @@ public sealed class Auth
     private readonly IUserStore _users;
     public Auth(IUserStore users) => _users = users;
 
+    // Checks if username already exists
+    public bool UsernameExists(string username)
+    {
+        username = (username ?? "").Trim();
+        return _users.Exists(username);
+    }
+
     public bool Register(string username, string password)
     {
         username = (username ?? "").Trim();
+        if (_users.Exists(username) || username.Length == 0) return false;
+
         password = (password ?? "").Trim();
-        if (username.Length == 0 || password.Length == 0) return false;
-        if (_users.Exists(username)) return false;
+        if (password.Length == 0) return false;
+        
 
         _users.Add(new User(username, password));
         return true;

--- a/BrickBreaker.UI/Program.cs
+++ b/BrickBreaker.UI/Program.cs
@@ -123,9 +123,27 @@ class Program
     // =========================
     // Helper methods
     // =========================
+
     static void DoRegister()
     {
         var username = _dialogs.PromptNewUsername();
+
+        username = (username ?? "").Trim();
+
+        // Checks so username is not empty 
+        if(username.Length == 0)
+        {
+            _dialogs.ShowMessage("Username can't be empty.");
+            return;
+        }
+
+        // Checks so username don´t already exists
+        if (_auth.UsernameExists(username))
+        {
+            _dialogs.ShowMessage("Username already exists.");
+            return;
+        }
+
         var password = _dialogs.PromptNewPassword();
 
         bool ok = _auth.Register(username, password);


### PR DESCRIPTION
Problem
In the current registration flow, the program asks the user for both username and password before verifying whether the username is valid (non-empty and not already taken). This results in unnecessary input steps and a confusing UX.

Task
Refactor the registration prompt so that:

The user enters a username.

The program immediately checks:

username is not empty/whitespace
username does not already exist in the user store
Only if the username is valid, prompt for the password.

If invalid, show a short message and return to the menu.

Goal
Ensure the program validates the username early and does not ask for a password when the username cannot be used.