### PR TITLE
Fix encoding issue for Spectre's Unicode borders

### DIFF
--- a/BrickBreaker.UI/Program.cs
+++ b/BrickBreaker.UI/Program.cs
@@ -10,6 +10,7 @@ using BrickBreaker.UI.Ui.SpecterConsole;
 using Spectre.Console;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 class Program
 {
     static string? currentUser = null ;
@@ -27,6 +28,8 @@ class Program
 
     static void Main()
     {
+        Console.OutputEncoding = Encoding.UTF8;
+
         var storageConfig = new StorageConfiguration();
         var connectionString = storageConfig.GetConnectionString();
 


### PR DESCRIPTION
I had an issue where on the first run of the program I was getting "unknown character" diamonds instead of the Leaderboard table borders, but if I exited the program and started again, it was fixed.

<img width="438" height="319" alt="image" src="https://github.com/user-attachments/assets/ce2f6938-96ac-44a6-85ad-c90d79ae43b1" />

Now it sets up the console encoding right on startup. 